### PR TITLE
Export public and media

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -3,6 +3,9 @@ namespace Export;
 
 use Laminas\EventManager\SharedEventManagerInterface;
 use Omeka\Module\AbstractModule;
+use Omeka\Form\SiteSettingsForm;
+use Export\Form\SiteSettingsFieldset;
+use Laminas\EventManager\Event;
 
 class Module extends AbstractModule
 {
@@ -23,10 +26,64 @@ class Module extends AbstractModule
             'view.show.sidebar',
             [$this, 'echoExportButtonHtml']
         );
+        $sharedEventManager->attach(
+            'Omeka\Controller\Admin\Media',
+            'view.show.sidebar',
+            [$this, 'echoExportButtonHtml']
+        );
+        $sharedEventManager->attach(
+            'Omeka\Controller\Site\Item',
+            'view.show.after',
+            [$this, 'echoExportButtonHtml']
+        );
+
+        $sharedEventManager->attach(
+            'Omeka\Controller\Site\Media',
+            'view.show.after',
+            [$this, 'echoExportButtonHtml']
+        );
+        $sharedEventManager->attach(
+            SiteSettingsForm::class,
+            'form.add_elements',
+            [$this, 'onSiteSettingsFormAddElements']
+        );
+        $sharedEventManager->attach(
+            'Omeka\Controller\Admin\Item',
+            'view.browse.before',
+            [$this, 'addAdminExportJs']
+        );
     }
     public function echoExportButtonHtml($event)
     {
         $view = $event->getTarget();
-        echo $view->exportButton();
+        echo $view->partial('export/exportbutton');
+    }
+    public function onSiteSettingsFormAddElements($event)
+    {
+        $services = $this->getServiceLocator();
+        $forms = $services->get('FormElementManager');
+        $siteSettings = $services->get('Omeka\Settings\Site');
+
+        $fieldset = $forms->get(SiteSettingsFieldset::class);
+        $fieldset->populateValues([
+            'export_show_after_item' => $siteSettings->get('export_show_after_item'),
+            'export_show_after_media' => $siteSettings->get('export_show_after_media'),
+        ]);
+        $form = $event->getTarget();
+        $groups = $form->getOption('element_groups');
+        if (isset($groups)) {
+            $groups['export'] = $fieldset->getLabel();
+            $form->setOption('element_groups', $groups);
+            foreach ($fieldset->getElements() as $element) {
+                $form->add($element);
+            }
+        } else {
+            $form->add($fieldset);
+        }
+    }
+    public function addAdminExportJs(Event $event): void
+    {
+        $view = $event->getTarget();
+        $view->headScript()->appendFile($view->assetUrl('js/export-button.js', 'Export'), 'text/javascript', ['defer' => 'defer']);
     }
 }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Installation
 
 See general end user documentation for [Installing a module](http://omeka.org/s/docs/user-manual/modules/#installing-modules).
 
+Usage
+-----
+
+Site display settings are made in the site parameters.
+
 Warning
 -------
 

--- a/asset/js/export-button.js
+++ b/asset/js/export-button.js
@@ -1,0 +1,24 @@
+/**
+* Initially based on Omeka S omeka2importer.js and resource-core.js.
+*/
+
+
+    (function ($) {
+        $(document).ready(function () {
+            const itemsCheckbox = $("input[type='checkbox'][name='resource_ids[]']");
+            const exportButton = $('#exportcsvbutton');
+            const selectAll= exportButton.closest('.select-all');
+            
+            function updateExportButton() {
+                if (itemsCheckbox.filter(':checked').length === 0) {
+                    exportButton.text('Total Export');
+                } else
+                exportButton.text('Export Selection')
+            }
+    
+            itemsCheckbox.on("click", updateExportButton);
+            updateExportButton();
+    
+        });
+    })(jQuery);
+    

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -62,6 +62,35 @@ return [
                     ],
                 ],
             ],
+            'site' => [
+                'child_routes' => [
+                    'export' => [
+                        'type' => 'Literal',
+                        'options' => [
+                            'route' => '/export',
+                            'defaults' => [
+                                '__NAMESPACE__' => 'Export\Controller',
+                                'controller' => 'Index',
+                                'action' => 'export',
+                            ],
+                        ],
+                        'may_terminate' => true,
+                        'child_routes' => [
+                            'download' => [
+                                'type' => 'Literal',
+                                'options' => [
+                                    'route' => '/download',
+                                    'defaults' => [
+                                        '__NAMESPACE__' => 'Export\Controller',
+                                        'controller' => 'Index',
+                                        'action' => 'download',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
         ],
     ],
 

--- a/config/module.ini
+++ b/config/module.ini
@@ -1,11 +1,11 @@
 [info]
-name = "Export"
-description = "Export collection metadata into a CSV file."
+name = "Export CSV"
+description = "Export resource metadata into a CSV file from (Admin and Site)."
 tags = "export, csv, spreadsheet, bulk edit, bulk update"
 license = "GPLv3"
 author = "BibLibre based on Laura Eiford export module"
 author_link = "https://github.com/biblibre"
 module_link = "https://github.com/biblibre/omeka-s-module-Export"
 configurable = false
-version = "1.8.0"
+version = "1.9.0"
 omeka_version_constraint = "^3.0.0 || ^4.0.0"

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -17,9 +17,9 @@ class Exporter
         $services = $this->application->getServiceManager();
         $api = $services->get('Omeka\ApiManager');
 
-        $item[] = $api->search('items', ['id' => $query])->getContent()[0];
+        $resource[] = $api->read('resources', ['id' => $query])->getContent();
 
-        $this->transformToCSV($item);
+        $this->transformToCSV($resource);
     }
 
     public function downloadSelected($query)

--- a/src/Form/SiteSettingsFieldset.php
+++ b/src/Form/SiteSettingsFieldset.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Export\Form;
+
+use Laminas\Form\Fieldset;
+use Laminas\Form\Element\Checkbox;
+
+class SiteSettingsFieldset extends Fieldset
+{
+    public function init()
+    {
+        $this->setName('export');
+        $this->setLabel('Export'); // @translate
+
+        $this->add([
+            'type' => Checkbox::class,
+            'name' => 'export_show_after_item',
+            'options' => [
+                'label' => 'Show on item page', // @translate
+                'element_group' => 'export',
+            ],
+        ]);
+
+        $this->add([
+            'type' => Checkbox::class,
+            'name' => 'export_show_after_media',
+            'options' => [
+                'label' => 'Show on media page', // @translate
+                'element_group' => 'export',
+            ],
+        ]);
+    }
+}

--- a/src/View/Helper/ExportButton.php
+++ b/src/View/Helper/ExportButton.php
@@ -4,6 +4,7 @@ namespace Export\View\Helper;
 
 use Laminas\View\Helper\AbstractHelper;
 use Laminas\Mvc\Application;
+use Export\view\Helper\ExportButton as OriginalButton;
 
 class ExportButton extends AbstractHelper
 {
@@ -14,7 +15,7 @@ class ExportButton extends AbstractHelper
         $this->application = $application;
     }
 
-    public function __invoke()
+    public function __invoke($exportSelection = false)
     {
         $mvcEvent = $this->application->getMvcEvent();
         $request = $mvcEvent->getRequest();
@@ -26,21 +27,35 @@ class ExportButton extends AbstractHelper
         $view = $this->getView();
         $onResultPage = true;
 
-        if ($route === 'admin/id' && ($params['controller'] === 'Omeka\Controller\Admin\Item' && $params['action'] === 'show')) {
+        $isAdminController = in_array($params['controller'], ['Omeka\Controller\Admin\Item', 'Omeka\Controller\Admin\Media']);
+        $isSiteController = in_array($params['controller'], ['Omeka\Controller\Site\Item', 'Omeka\Controller\Site\Media']);
+        $isShowAction = $params['action'] === 'show' ? true : null;
+
+        if (
+            (
+                ($route === 'admin/id' && $isAdminController) ||
+                ($route === 'site/resource-id' && $isSiteController)
+            ) &&
+            isset($isShowAction)
+        ) {
             $query = [
-            'id' => $params['id'],
-           ];
+                'id' => $params['id'],
+            ];
             $onResultPage = false;
         } else {
             $query = $request->getQuery()->toArray();
         }
 
-        $url = $view->url('admin/export/download', [], ['query' => $query]);
+        if ($isAdminController) {
+            $url = $view->url('admin/export/download', [], ['query' => $query + ['exportSelection' => $exportSelection]], true);
+        } else if ($isSiteController) {
+            $url = $view->url('site/export/download', [], ['query' => $query + ['exportSelection' => $exportSelection]], true);
+        }
 
-        if ($onResultPage) {
-            return '<button form="batch-form" formaction="' . $url . '">Export CSV</button>';
+        if ($onResultPage && $isAdminController) {
+            return '<button id="exportcsvbutton" form="batch-form" formaction="' . $url . '"></button>';
         } else {
-            return '<a href="' . $url . '"><button>Export CSV</button></a>';
+            return '<a href="' . $url . '"><button id="exportcsvbutton">Export CSV</button></a>';
         }
     }
 }

--- a/view/export/exportbutton.phtml
+++ b/view/export/exportbutton.phtml
@@ -1,0 +1,2 @@
+<?php echo $this->exportButton();
+?>


### PR DESCRIPTION
Admin side:

- from the media notice, make it possible to export the notice
- improve display of export button according to context (selection or total export)

Public side:

- from the item/media notice, make it possible to export the notice
- make it possible to overload by theme (eg: do not display the export button if the notice is linked to a specific group)
- make an option in the admin to choose what is possible to export on the public side (item/media)