### PR TITLE
Export CSV selected values in correct format

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -683,11 +683,7 @@ class Exporter
 
                             elseif (isset($single['@value'])) {
                                 $formattedValue = $single['@value'];
-                            }
-
-                            elseif (isset($single['@id'])) {
-                                $formattedValue = $this->getLabelFromRepresentation($single['@id']) ?? $single['@id'];
-                            }
+                            } 
                             
                             elseif (isset($single['o:id'])) {
                                 $formattedValue = $single['o:id'];

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -657,49 +657,43 @@ class Exporter
                 if (array_key_exists($column, $item)) {
                     $row = $item[$column];
                     if (is_array($row)) {
-                       $valueEntries = (isset($row['@value']) || isset($row['@id']) || isset($row['type'])) ? [$row] : $row;
-    
+                        $valueEntries = (isset($row['@value']) || isset($row['@id']) || isset($row['type'])) ? [$row] : $row;
+
                         $cellValues = [];
 
                         foreach ($valueEntries as $single) {
                             if (!is_array($single)) {
-                                $val = trim((string) $single);
-                                 if ($val !== "") {
+                                $val = $single;
+                                if ($val !== "") {
                                     $cellValues[] = $val;
-                                 }
+                                }
                                 continue;
                             }
 
                             $formattedValue = "";
 
                             if (isset($single['@value'])) {
-                                $formattedValue = trim($single['@value']);
-                            } 
-
-                            elseif (isset($single['type']) && $single['type'] === 'uri') {
-                                        $url = $single['@id'] ?? '';
-                                        $label = !empty($single['o:label']) ? $single['o:label'] : $url;
+                                $formattedValue = $single['@value'];
+                            } elseif (isset($single['type']) && $single['type'] === 'uri') {
+                                $url = $single['@id'] ?? '';
+                                $label = !empty($single['o:label']) ? $single['o:label'] : $url;
                                 $formattedValue = (empty($label)) ? $url : $label . ":" . $url;
-                            }
-                            
-                            elseif (isset($single['type']) && $single['type'] === 'resource') {
+                            } elseif (isset($single['type']) && $single['type'] === 'resource') {
                                 $label = $this->getLabelFromRepresentation($single['@id']);
-        
+
                                 if (!$label) {
-                                    $label = $single['display_title'] ?? "Resource " . ($single['value_resource_id'] ?? $single['o:id'] ?? 'unknown');
+                                    $label = 'Titlllleeeeee';
                                 }
-        
+
                                 $url = $single['@id'];
-                                $formattedValue = trim($label) . ":" . $url;
-                            }
-                            
-                            elseif (isset($single['@id'])) {
+                                $formattedValue = $label . ":" . $url;
+                            } elseif (isset($single['@id'])) {
                                 $idUrl = $single['@id'];
                                 $parts = explode("api/", $idUrl);
-        
+
                                 if (isset($parts[1]) && strpos($parts[1], '/') !== false) {
                                     $label = $this->getLabelFromRepresentation($idUrl);
-                                     $formattedValue = $label ? trim($label) : $idUrl;
+                                    $formattedValue = $label ? $label : $idUrl;
                                 } else {
                                     $formattedValue = $idUrl;
                                 }
@@ -711,7 +705,7 @@ class Exporter
                         }
 
                         $valueToPush = implode("; ", $cellValues);
-                                            
+                        $valueToPush = $valueToPush;
                     } else {
                         $valueToPush = $row;
                     }
@@ -720,10 +714,9 @@ class Exporter
                 }
 
                 if (is_string($valueToPush)) {
-                    if (trim($valueToPush) !== "") {
-                        $usedColumns[$column] = true;
-                    }
-                } elseif ($valueToPush !== null && $valueToPush !== "") {
+                    $valueToPush = trim($valueToPush);
+                }
+                if ($valueToPush !== null && $valueToPush !== "") {
                     $usedColumns[$column] = true;
                 }
 

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -663,35 +663,58 @@ class Exporter
 
                         foreach ($valueEntries as $single) {
                             if (!is_array($single)) {
-                                $cellValues[] = $single;
-                                continue;
-                            }
+        $val = trim((string) $single);
+        if ($val !== "") {
+            $cellValues[] = $val;
+        }
+        continue;
+    }
 
-                            $formattedValue = "";
+    $formattedValue = "";
 
-                            if (isset($single['type']) && $single['type'] === 'uri') {
-                                $label = !empty($single['o:label']) ? $single['o:label'] : $single['@id'];
-                                $url = $single['@id'];
-                                $formattedValue = (empty($label)) ? $url : $label . ":" . $url;
-                            } 
-                            
-                            elseif (isset($single['type']) && $single['type'] === 'resource') {
-                                $label = $this->getLabelFromRepresentation($single['@id']) ?? "Resource " . ($single['value_resource_id'] ?? '');  
-                                $url = $single['@id'];
-                                $formattedValue = $label . ":" . $url;
-                            }
+    // PRIORITÉ 1 : Le texte pur (@value) - On le traite en premier comme suggéré
+    if (isset($single['@value'])) {
+        $formattedValue = trim($single['@value']);
+    } 
+    
+    // PRIORITÉ 2 : Les URI (Liens externes)
+    elseif (isset($single['type']) && $single['type'] === 'uri') {
+        $url = $single['@id'] ?? '';
+        $label = !empty($single['o:label']) ? $single['o:label'] : $url;
+        $formattedValue = ($label === $url) ? $url : trim($label) . ":" . $url;
+    } 
+    
+    // PRIORITÉ 3 : Les Ressources Omeka (Liens internes)
+    elseif (isset($single['type']) && $single['type'] === 'resource') {
+        // On cherche le titre. Si getLabel échoue, on tente un fallback sur le display_title
+        $label = $this->getLabelFromRepresentation($single['@id']);
+        
+        if (!$label) {
+            $label = $single['display_title'] ?? "Resource " . ($single['value_resource_id'] ?? $single['o:id'] ?? 'unknown');
+        }
+        
+        $url = $single['@id'];
+        $formattedValue = trim($label) . ":" . $url;
+    }
 
-                            elseif (isset($single['@value'])) {
-                                $formattedValue = $single['@value'];
-                            } 
-                            
-                            elseif (isset($single['o:id'])) {
-                                $formattedValue = $single['o:id'];
-                            }
+    // PRIORITÉ 4 : Les objets techniques (@id sans type particulier)
+    // On vérifie le format pour éviter l'erreur de la ligne 815
+    elseif (isset($single['@id'])) {
+        $idUrl = $single['@id'];
+        $parts = explode("api/", $idUrl);
+        
+        if (isset($parts[1]) && strpos($parts[1], '/') !== false) {
+            $label = $this->getLabelFromRepresentation($idUrl);
+            $formattedValue = $label ? trim($label) : $idUrl;
+        } else {
+            $formattedValue = $idUrl;
+        }
+    }
 
-                            if ($formattedValue !== "") {
-                                $cellValues[] = $formattedValue;
-                            }
+    // Ajout final au tableau de la cellule
+    if ($formattedValue !== "") {
+        $cellValues[] = $formattedValue;
+    }
                         }
 
                         $valueToPush = implode("; ", $cellValues);

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -657,31 +657,49 @@ class Exporter
                 if (array_key_exists($column, $item)) {
                     $row = $item[$column];
                     if (is_array($row)) {
-                        if (isset($row['@id'])) {
-                            $labelEntity = $this->getLabelFromRepresentation($row['@id']);
-                            if (isset($labelEntity)) {
-                                $valueToPush = $labelEntity;
+                       $valueEntries = (isset($row['@value']) || isset($row['@id']) || isset($row['type'])) ? [$row] : $row;
+    
+                        $cellValues = [];
+
+                        foreach ($valueEntries as $single) {
+                            if (!is_array($single)) {
+                                $cellValues[] = $single;
+                                continue;
                             }
-                        } elseif (array_key_exists('@value', $row)) {
-                            $valueToPush = $row['@value'];
-                        } else {
-                            $multiRow = "";
-                            foreach ($row as $single) {
-                                if (is_array($single)) {
-                                    if ($single['@id']) {
-                                        $labelEntity = $this->getLabelFromRepresentation($single['@id']);
-                                        if ($labelEntity) {
-                                            $multiRow .= ";" . $labelEntity;
-                                        }
-                                    } elseif (array_key_exists('@value', $single)) {
-                                        $multiRow .= ";" . $single['@value'];
-                                    }
-                                } else {
-                                    $multiRow .= ";" . $single;
-                                }
+
+                            $formattedValue = "";
+
+                            if (isset($single['type']) && $single['type'] === 'uri') {
+                                $label = !empty($single['o:label']) ? $single['o:label'] : $single['@id'];
+                                $url = $single['@id'];
+                                $formattedValue = (empty($label)) ? $url : $label . ":" . $url;
+                            } 
+                            
+                            elseif (isset($single['type']) && $single['type'] === 'resource') {
+                                $label = $this->getLabelFromRepresentation($single['@id']) ?? "Resource " . ($single['value_resource_id'] ?? '');  
+                                $url = $single['@id'];
+                                $formattedValue = $label . ":" . $url;
                             }
-                            $valueToPush = ltrim($multiRow, ";");
+
+                            elseif (isset($single['@value'])) {
+                                $formattedValue = $single['@value'];
+                            }
+
+                            elseif (isset($single['@id'])) {
+                                $formattedValue = $this->getLabelFromRepresentation($single['@id']) ?? $single['@id'];
+                            }
+                            
+                            elseif (isset($single['o:id'])) {
+                                $formattedValue = $single['o:id'];
+                            }
+
+                            if ($formattedValue !== "") {
+                                $cellValues[] = $formattedValue;
+                            }
                         }
+
+                        $valueToPush = implode("; ", $cellValues);
+                                            
                     } else {
                         $valueToPush = $row;
                     }

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -663,58 +663,51 @@ class Exporter
 
                         foreach ($valueEntries as $single) {
                             if (!is_array($single)) {
-        $val = trim((string) $single);
-        if ($val !== "") {
-            $cellValues[] = $val;
-        }
-        continue;
-    }
+                                $val = trim((string) $single);
+                                 if ($val !== "") {
+                                    $cellValues[] = $val;
+                                 }
+                                continue;
+                            }
 
-    $formattedValue = "";
+                            $formattedValue = "";
 
-    // PRIORITÉ 1 : Le texte pur (@value) - On le traite en premier comme suggéré
-    if (isset($single['@value'])) {
-        $formattedValue = trim($single['@value']);
-    } 
-    
-    // PRIORITÉ 2 : Les URI (Liens externes)
-    elseif (isset($single['type']) && $single['type'] === 'uri') {
-        $url = $single['@id'] ?? '';
-        $label = !empty($single['o:label']) ? $single['o:label'] : $url;
-        $formattedValue = ($label === $url) ? $url : trim($label) . ":" . $url;
-    } 
-    
-    // PRIORITÉ 3 : Les Ressources Omeka (Liens internes)
-    elseif (isset($single['type']) && $single['type'] === 'resource') {
-        // On cherche le titre. Si getLabel échoue, on tente un fallback sur le display_title
-        $label = $this->getLabelFromRepresentation($single['@id']);
+                            if (isset($single['@value'])) {
+                                $formattedValue = trim($single['@value']);
+                            } 
+
+                            elseif (isset($single['type']) && $single['type'] === 'uri') {
+                                        $url = $single['@id'] ?? '';
+                                        $label = !empty($single['o:label']) ? $single['o:label'] : $url;
+                                $formattedValue = (empty($label)) ? $url : $label . ":" . $url;
+                            }
+                            
+                            elseif (isset($single['type']) && $single['type'] === 'resource') {
+                                $label = $this->getLabelFromRepresentation($single['@id']);
         
-        if (!$label) {
-            $label = $single['display_title'] ?? "Resource " . ($single['value_resource_id'] ?? $single['o:id'] ?? 'unknown');
-        }
+                                if (!$label) {
+                                    $label = $single['display_title'] ?? "Resource " . ($single['value_resource_id'] ?? $single['o:id'] ?? 'unknown');
+                                }
         
-        $url = $single['@id'];
-        $formattedValue = trim($label) . ":" . $url;
-    }
-
-    // PRIORITÉ 4 : Les objets techniques (@id sans type particulier)
-    // On vérifie le format pour éviter l'erreur de la ligne 815
-    elseif (isset($single['@id'])) {
-        $idUrl = $single['@id'];
-        $parts = explode("api/", $idUrl);
+                                $url = $single['@id'];
+                                $formattedValue = trim($label) . ":" . $url;
+                            }
+                            
+                            elseif (isset($single['@id'])) {
+                                $idUrl = $single['@id'];
+                                $parts = explode("api/", $idUrl);
         
-        if (isset($parts[1]) && strpos($parts[1], '/') !== false) {
-            $label = $this->getLabelFromRepresentation($idUrl);
-            $formattedValue = $label ? trim($label) : $idUrl;
-        } else {
-            $formattedValue = $idUrl;
-        }
-    }
+                                if (isset($parts[1]) && strpos($parts[1], '/') !== false) {
+                                    $label = $this->getLabelFromRepresentation($idUrl);
+                                     $formattedValue = $label ? trim($label) : $idUrl;
+                                } else {
+                                    $formattedValue = $idUrl;
+                                }
+                            }
 
-    // Ajout final au tableau de la cellule
-    if ($formattedValue !== "") {
-        $cellValues[] = $formattedValue;
-    }
+                            if ($formattedValue !== "") {
+                                $cellValues[] = $formattedValue;
+                            }
                         }
 
                         $valueToPush = implode("; ", $cellValues);


### PR DESCRIPTION
Fix CSV export to include: label and URL for text, URI, and resource fields.

When exporting a resource:

    Plain text is exported as-is
    URIs include label and URL (label:URL)
    Internal resources include label and item URL (label:URL)
    Multiple values are concatenated in the same cell with ;
    Values appear in the default order of Omeka

Tested with a resource containing text, URI, and linked resource. CSV now correctly shows all values in the same cell.