### PR TITLE
Restore missing URI values and add URLs to CSV export

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -660,7 +660,11 @@ class Exporter
                         if (isset($row['@id'])) {
 
                             if (isset($row['type']) && $row['type'] === 'uri') {
-                                $valueToPush = $row['o:label'] . ":" . $row['@id'];
+                                if (isset($single['o:label'])) {
+                                    $valueToPush = $row['o:label'] . ":" . $row['@id'];
+                                } else {
+                                    $valueToPush = $row['@id'];
+                                }
                             }
 
                             if (isset($row['type']) && $row['type'] === 'resource') {
@@ -683,7 +687,7 @@ class Exporter
                                     if (isset($single['@id'])) {
 
                                         if (isset($single['type']) && $single['type'] === 'uri') {
-                                            if (isset($single['o:label']) && trim($single['o:label']) !== "") {
+                                            if (isset($single['o:label'])) {
                                                 $multiRow .= "; " . $single['o:label'] . ":" . $single['@id'];
                                             } else {
                                                 $multiRow .= "; " . $single['@id'];

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -664,14 +664,14 @@ class Exporter
                             }
 
                             if (isset($row['type']) && $row['type'] === 'resource') {
-                                $labelEntity = $this->getLabelFromRepresentation($row['@id']);
+                                $labelEntity = $row['display_title'];
                                 if (isset($labelEntity)) {
                                     $valueToPush = $labelEntity . ":" . $row['@id'];
                                 }
                             } else {
                                 $labelEntity = $this->getLabelFromRepresentation($row['@id']);
                                 if (isset($labelEntity)) {
-                                    $valueToPush = $labelEntity; // lien ? 
+                                    $valueToPush = $labelEntity;
                                 }
                             }
                         } elseif (array_key_exists('@value', $row)) {
@@ -683,18 +683,22 @@ class Exporter
                                     if (isset($single['@id'])) {
 
                                         if (isset($single['type']) && $single['type'] === 'uri') {
-                                            $multiRow .= "; " . $single['o:label'] . ":" . $single['@id'];
+                                            if (!empty($single['o:label'])) {
+                                                $multiRow .= "; " . $single['o:label'] . ":" . $single['@id'];
+                                            } else {
+                                                $multiRow .= "; " . $single['@id'];
+                                            }
                                         }
 
                                         if (isset($single['type']) && $single['type'] === 'resource') {
-                                            $labelEntity = $this->getLabelFromRepresentation($single['@id']);
+                                            $labelEntity = $single['display_title'];
                                             if (isset($labelEntity)) {
                                                 $multiRow .= "; " . $labelEntity . ":" . $single['@id'];
                                             }
                                         } else {
                                             $labelEntity = $this->getLabelFromRepresentation($single['@id']);
                                             if (isset($labelEntity)) {
-                                                $multiRow .= "; " . $labelEntity; // lien ?  . ":" . $single['@id'] 
+                                                $multiRow .= "; " . $labelEntity;
                                             }
                                         }
                                     } elseif (array_key_exists('@value', $single)) {

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -658,9 +658,21 @@ class Exporter
                     $row = $item[$column];
                     if (is_array($row)) {
                         if (isset($row['@id'])) {
-                            $labelEntity = $this->getLabelFromRepresentation($row['@id']);
-                            if (isset($labelEntity)) {
-                                $valueToPush = $labelEntity;
+
+                            if (isset($row['type']) && $row['type'] === 'uri') {
+                                $valueToPush = $row['o:label'] . ":" . $row['@id'];
+                            }
+
+                            if (isset($row['type']) && $row['type'] === 'resource') {
+                                $labelEntity = $this->getLabelFromRepresentation($row['@id']);
+                                if (isset($labelEntity)) {
+                                    $valueToPush = $labelEntity . ":" . $row['@id'];
+                                }
+                            } else {
+                                $labelEntity = $this->getLabelFromRepresentation($row['@id']);
+                                if (isset($labelEntity)) {
+                                    $valueToPush = $labelEntity; // lien ? 
+                                }
                             }
                         } elseif (array_key_exists('@value', $row)) {
                             $valueToPush = $row['@value'];
@@ -669,9 +681,21 @@ class Exporter
                             foreach ($row as $single) {
                                 if (is_array($single)) {
                                     if (isset($single['@id'])) {
-                                        $labelEntity = $this->getLabelFromRepresentation($single['@id']);
-                                        if ($labelEntity) {
-                                            $multiRow .= "; " . $labelEntity;
+
+                                        if (isset($single['type']) && $single['type'] === 'uri') {
+                                            $multiRow .= "; " . $single['o:label'] . ":" . $single['@id'];
+                                        }
+
+                                        if (isset($single['type']) && $single['type'] === 'resource') {
+                                            $labelEntity = $this->getLabelFromRepresentation($single['@id']);
+                                            if (isset($labelEntity)) {
+                                                $multiRow .= "; " . $labelEntity . ":" . $single['@id'];
+                                            }
+                                        } else {
+                                            $labelEntity = $this->getLabelFromRepresentation($single['@id']);
+                                            if (isset($labelEntity)) {
+                                                $multiRow .= "; " . $labelEntity; // lien ?  . ":" . $single['@id'] 
+                                            }
                                         }
                                     } elseif (array_key_exists('@value', $single)) {
                                         $multiRow .= "; " . $single['@value'];

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -683,7 +683,7 @@ class Exporter
                                     if (isset($single['@id'])) {
 
                                         if (isset($single['type']) && $single['type'] === 'uri') {
-                                            if (!empty($single['o:label'])) {
+                                            if (isset($single['o:label']) && trim($single['o:label']) !== "") {
                                                 $multiRow .= "; " . $single['o:label'] . ":" . $single['@id'];
                                             } else {
                                                 $multiRow .= "; " . $single['@id'];

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -671,16 +671,16 @@ class Exporter
                                     if (isset($single['@id'])) {
                                         $labelEntity = $this->getLabelFromRepresentation($single['@id']);
                                         if ($labelEntity) {
-                                            $multiRow .= ";" . $labelEntity;
+                                            $multiRow .= "; " . $labelEntity;
                                         }
                                     } elseif (array_key_exists('@value', $single)) {
-                                        $multiRow .= ";" . $single['@value'];
+                                        $multiRow .= "; " . $single['@value'];
                                     }
                                 } else {
-                                    $multiRow .= ";" . $single;
+                                    $multiRow .= "; " . $single;
                                 }
                             }
-                            $valueToPush = ltrim($multiRow, ";");
+                            $valueToPush = ltrim($multiRow, "; ");
                         }
                     } else {
                         $valueToPush = $row;


### PR DESCRIPTION
Fix CSV export to include: label and URL for text, URI, and resource fields.

When exporting a resource:

Plain text is exported as-is
URIs include label and URL (label:URL)
Internal resources include label and item URL (label:URL)
Multiple values are concatenated in the same cell with ;
Values appear in the default order of Omeka

Tested with a resource containing text, URI, and linked resource. CSV now correctly shows all values in the same cell.
