### PR TITLE
Restore missing URI values and add URLs to CSV export

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -661,9 +661,25 @@ class Exporter
                     $row = $item[$column];
                     if (is_array($row)) {
                         if (isset($row['@id'])) {
-                            $labelEntity = $this->getLabelFromRepresentation($row['@id']);
-                            if (isset($labelEntity)) {
-                                $valueToPush = $labelEntity;
+
+                            if (isset($row['type']) && $row['type'] === 'uri') {
+                                if (isset($single['o:label'])) {
+                                    $valueToPush = $row['o:label'] . ":" . $row['@id'];
+                                } else {
+                                    $valueToPush = $row['@id'];
+                                }
+                            }
+
+                            if (isset($row['type']) && $row['type'] === 'resource') {
+                                $resourceTitle = $row['display_title'];
+                                if (isset($resourceTitle)) {
+                                    $valueToPush = $resourceTitle . ":" . $row['@id'];
+                                }
+                            } else {
+                                $labelEntity = $this->getLabelFromRepresentation($row['@id']);
+                                if (isset($labelEntity)) {
+                                    $valueToPush = $labelEntity;
+                                }
                             }
                         } elseif (array_key_exists('@value', $row)) {
                             $valueToPush = $row['@value'];
@@ -672,9 +688,25 @@ class Exporter
                             foreach ($row as $single) {
                                 if (is_array($single)) {
                                     if (isset($single['@id'])) {
-                                        $labelEntity = $this->getLabelFromRepresentation($single['@id']);
-                                        if ($labelEntity) {
-                                            $multiRow .= ";" . $labelEntity;
+
+                                        if (isset($single['type']) && $single['type'] === 'uri') {
+                                            if (isset($single['o:label'])) {
+                                                $multiRow .= ";" . $single['o:label'] . ":" . $single['@id'];
+                                            } else {
+                                                $multiRow .= ";" . $single['@id'];
+                                            }
+                                        }
+
+                                        if (isset($single['type']) && $single['type'] === 'resource') {
+                                            $resourceTitle = $single['display_title'];
+                                            if (isset($resourceTitle)) {
+                                                $multiRow .= ";" . $resourceTitle . ":" . $single['@id'];
+                                            }
+                                        } else {
+                                            $labelEntity = $this->getLabelFromRepresentation($single['@id']);
+                                            if (isset($labelEntity)) {
+                                                $multiRow .= ";" . $labelEntity;
+                                            }
                                         }
                                     } elseif (array_key_exists('@value', $single)) {
                                         $multiRow .= ";" . $single['@value'];

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -663,14 +663,12 @@ class Exporter
                         if (isset($row['@id'])) {
 
                             if (isset($row['type']) && $row['type'] === 'uri') {
-                                if (isset($single['o:label'])) {
+                                if (isset($row['o:label'])) {
                                     $valueToPush = $row['o:label'] . ":" . $row['@id'];
                                 } else {
                                     $valueToPush = $row['@id'];
                                 }
-                            }
-
-                            if (isset($row['type']) && $row['type'] === 'resource') {
+                            } elseif (isset($row['type']) && $row['type'] === 'resource') {
                                 $resourceTitle = $row['display_title'];
                                 if (isset($resourceTitle)) {
                                     $valueToPush = $resourceTitle . ":" . $row['@id'];
@@ -695,9 +693,7 @@ class Exporter
                                             } else {
                                                 $multiRow .= ";" . $single['@id'];
                                             }
-                                        }
-
-                                        if (isset($single['type']) && $single['type'] === 'resource') {
+                                        } elseif (isset($single['type']) && $single['type'] === 'resource') {
                                             $resourceTitle = $single['display_title'];
                                             if (isset($resourceTitle)) {
                                                 $multiRow .= ";" . $resourceTitle . ":" . $single['@id'];


### PR DESCRIPTION
Fix CSV export to include: label and URL for text, URI, and resource fields.

When exporting a resource:

Plain text is exported as-is
URIs include label and URL (label:URL)
Internal resources include label and item URL (label:URL)
Multiple values are concatenated in the same cell with ;
Values appear in the default order of Omeka

Tested with a resource containing text, URI, and linked resource. CSV now correctly shows all values in the same cell.